### PR TITLE
Support Viewing into Requester Pays Buckets

### DIFF
--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -497,7 +497,7 @@ class GoogleStorageContentManager(ContentsManager):
         """
         if not self.cache_buckets:
             try:
-                bucket_descriptor = self.client.bucket(name, user_project=self.project)
+                bucket_descriptor = self.client.bucket(name, user_project=self.client.project)
                 return self.client.get_bucket(bucket_descriptor)
             except NotFound:
                 if throw:
@@ -511,7 +511,7 @@ class GoogleStorageContentManager(ContentsManager):
             return cache[name]
         except KeyError:
             try:
-                bucket_descriptor = self.client.bucket(name, user_project=self.project)
+                bucket_descriptor = self.client.bucket(name, user_project=self.client.project)
                 bucket = self.client.get_bucket(bucket_descriptor)
             except BrokenPipeError as e:
                 if e.errno in (None, errno.EPIPE):

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -497,7 +497,8 @@ class GoogleStorageContentManager(ContentsManager):
         """
         if not self.cache_buckets:
             try:
-                return self.client.get_bucket(name)
+                bucket_descriptor = self.client.bucket(name, user_project=self.project)
+                return self.client.get_bucket(bucket_descriptor)
             except NotFound:
                 if throw:
                     raise
@@ -510,7 +511,8 @@ class GoogleStorageContentManager(ContentsManager):
             return cache[name]
         except KeyError:
             try:
-                bucket = self.client.get_bucket(name)
+                bucket_descriptor = self.client.bucket(name, user_project=self.project)
+                bucket = self.client.get_bucket(bucket_descriptor)
             except BrokenPipeError as e:
                 if e.errno in (None, errno.EPIPE):
                     return self._get_bucket(name, throw)


### PR DESCRIPTION
This PR enables jgscm to view inside of requester pays buckets by passing the current project as the `user_project` field. I think this is enough to stop any UI weirdness in jgscm with requester pays buckets. At the very least it's a first step and resolves some of the issues.

https://cloud.google.com/storage/docs/using-requester-pays#using