### PR TITLE
Fix definition of directory, fix performance of checking existence of directory, fix performance of listing directory, fix performance of opening new notebook

### DIFF
--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -768,7 +768,7 @@ class GoogleStorageContentManager(ContentsManager):
             else:
                 tmpl = "%s"
             _, this = self._parse_path(path)
-            with ThreadPoolExecutor(max_workers=32) as pool:
+            with ThreadPoolExecutor(max_workers=64) as pool:
                 blob_futures = [
                     pool.submit(self.get, path=blob, content=False)
                     for blob in blobs

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -615,9 +615,11 @@ class GoogleStorageContentManager(ContentsManager):
                 if exists and not content:
                     return True, None
             # blob may not exist but at the same time be a part of a path
+            delimiter = '/' if content else None  # https://github.com/hail-is/hail/issues/8586
             max_list_size = self.max_list_size if content else 1
             try:
-                it = bucket.list_blobs(prefix=bucket_path, delimiter="/",
+                it = bucket.list_blobs(prefix=bucket_path,
+                                       delimiter=delimiter,
                                        max_results=max_list_size)
                 try:
                     files = list(islice(it, max_list_size))

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -780,13 +780,9 @@ class GoogleStorageContentManager(ContentsManager):
                     if self.should_list(folder) and folder != this]
                 self.log.debug(f'running {len(blob_futures) + len(folder_futures)}'
                                f' 32-parallel')
-                content, failures = wait(blob_futures + folder_futures)
-                if failures:
-                    raise ValueError(
-                        f'retrieving directory contents failed: '
-                        f'{", ".join(failures)}'
-                    ) from failures[0]
-                model["content"] = content
+                done, not_done = wait(blob_futures + folder_futures)
+                assert not not_done
+                model["content"] = [x.result() for x in done]
             model["format"] = "json"
 
         return model

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -256,7 +256,9 @@ class GoogleStorageContentManager(ContentsManager):
         bucket = self._get_bucket(bucket_name)
         if bucket is None or bucket_path == "":
             return False
-        return bucket.blob(bucket_path).exists()
+        blob = bucket.blob(bucket_path)
+        return blob.exists() and not (
+            blob.name.endswith("/") and blob.size == 0)
 
     @debug_args
     def dir_exists(self, path):

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -215,6 +215,7 @@ class GoogleStorageContentManager(ContentsManager):
         # Stub for the GSClient instance (set lazily by the client property).
         self._client = None
         super(GoogleStorageContentManager, self).__init__(*args, **kwargs)
+        self.log.debug('using dk jgscm')
 
     def debug_args(fn):
         def wrapped_fn(self, *args, **kwargs):
@@ -777,8 +778,8 @@ class GoogleStorageContentManager(ContentsManager):
                     pool.submit(self.get, path=tmpl % folder, content=False)
                     for folder in folders
                     if self.should_list(folder) and folder != this]
-                print(f'running {len(blob_futures) + len(folder_futures)}'
-                      f' 32-parallel')
+                self.log.debug(f'running {len(blob_futures) + len(folder_futures)}'
+                               f' 32-parallel')
                 content, failures = wait(blob_futures + folder_futures)
                 if failures:
                     raise ValueError(

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -215,7 +215,6 @@ class GoogleStorageContentManager(ContentsManager):
         # Stub for the GSClient instance (set lazily by the client property).
         self._client = None
         super(GoogleStorageContentManager, self).__init__(*args, **kwargs)
-        self.log.debug('using dk jgscm')
 
     def debug_args(fn):
         def wrapped_fn(self, *args, **kwargs):

--- a/jgscm/__init__.py
+++ b/jgscm/__init__.py
@@ -777,6 +777,8 @@ class GoogleStorageContentManager(ContentsManager):
                     pool.submit(self.get, path=tmpl % folder, content=False)
                     for folder in folders
                     if self.should_list(folder) and folder != this]
+                print(f'running {len(blob_futures) + len(folder_futures)}'
+                      f' 32-parallel')
                 content, failures = wait(blob_futures + folder_futures)
                 if failures:
                     raise ValueError(


### PR DESCRIPTION
- fix definition of directory: files named `x/` with size zero indicate the existence of a directory on GCS. This is an undocumented convention. Hail (through the Google Haddop connector), for example, creates these.
- fix performance of checking existence of directory: not using `delimiter` when checking the existence of a directory (i.e. when `content` is falsey). for details see https://github.com/hail-is/hail/issues/8586
- fix performance of listing directory: a separate GCS API request is made for each file in a directory. Each request can take a second or more. This quickly becomes a UX nightmare. We use 64-way python parallelism when listing directories (i.e. inside `_dir_model`). Python does not have true parallelism due to the GIL, but blocking I/O calls release the GIL, so this enables 64 parallel requests to GCS.
- fix performance of opening new notebook: same cause as previous. creating a notebook re-lists the current directory.
